### PR TITLE
Update to X-Moto 0.6.2 and FreeDesktop SDK 22.08

### DIFF
--- a/app_fix.patch
+++ b/app_fix.patch
@@ -1,5 +1,5 @@
---- xmoto-0.6.1/src/common/VFileIO.cpp	2020-12-24 15:38:49.286118355 -0400
-+++ xmoto-0.6.1/src/common/VFileIO.cpp	2020-12-24 18:14:08.572174657 -0400
+--- xmoto-0.6.2/src/common/VFileIO.cpp	2020-12-24 15:38:49.286118355 -0400
++++ xmoto-0.6.2/src/common/VFileIO.cpp	2020-12-24 18:14:08.572174657 -0400
 @@ -1313,7 +1313,7 @@
    for (char const *const *c_dir = xdgDataDirectories(m_xdgHd); *c_dir != NULL;
         c_dir++) {

--- a/org.tuxfamily.XMoto.appdata.xml
+++ b/org.tuxfamily.XMoto.appdata.xml
@@ -21,8 +21,8 @@ SentUpstream: 2014-09-25
       solid object the level has to be restarted.
     </p>
     <p>
-      There are hundreds of levels available in xmoto, both included in the
-      initial install, and downloadable from the internet.
+      There are hundreds of levels available in X-Moto, both included in the
+      initial install, and downloadable from the Internet.
       There is also the
       ability to challenge fastest times with other players from around the world.
       and saved ghost data to visually see the runs of other players through the
@@ -40,15 +40,42 @@ SentUpstream: 2014-09-25
   </screenshots>
   <content_rating type="oars-1.1"/>
   <releases>
+    <release version="0.6.2" date="2023-03-05">
+      <description>
+        <ul>
+          <li>X-Moto now uses SDL2 for window handling, input, etc.</li>
+          <li>Added Shortcut to view level info</li>
+          <li>Added Shortcut for connecting / disconnecting from the server</li>
+          <li>Added Button for clearing level cache</li>
+          <li>Added File drag &amp; drop support</li>
+          <li>Added File associations</li>
+          <li>Added Support for high refresh rate screens</li>
+          <li>Improved controller support in menus</li>
+          <li>Default theme changed to 'Classic'</li>
+          <li>Safemode now prevents you from restarting in the death screen if a checkpoint has been reached</li>
+          <li>In 'beating mode', if you have not reached a checkpoint, the 'return to checkpoint' key takes you to the start of the level</li>
+          <li>Log files are now kept for longer</li>
+          <li>Improved UI text boxes (with pasting support and word jumping etc)</li>
+          <li>Admin console is now scrollable</li>
+          <li>Added Hide sprites in ugly mode and minimap option</li>
+          <li>Added Max frame rate option</li>
+          <li>Added Native/software cursor option</li>
+          <li>Updated Russian, Swedish and Danish translations</li>
+          <li>Fixed the window not being properly focused when alt-tabbing</li>
+          <li>Fixed various memory leaks and crashes</li>
+        </ul>
+      </description>
+      <url>https://xmoto.tuxfamily.org/dev/ChangeLog</url>
+    </release>
     <release version="0.6.1" date="2020-06-20">
-    <description>
-      <ul>
-        <li>Improved level load times.</li>
-        <li>Fixed a game crash with locales using comma (,) as decimal separator.</li>
-        <li>No more crashing on non-existent db entries when migrating from old version.</li>
-      </ul>
-    </description>
-    <url>https://xmoto.tuxfamily.org/dev/ChangeLog</url>
+      <description>
+        <ul>
+          <li>Improved level load times.</li>
+          <li>Fixed a game crash with locales using comma (,) as decimal separator.</li>
+          <li>No more crashing on non-existent db entries when migrating from old version.</li>
+        </ul>
+      </description>
+      <url>https://xmoto.tuxfamily.org/dev/ChangeLog</url>
     </release>
   </releases>
 </component>

--- a/org.tuxfamily.XMoto.json
+++ b/org.tuxfamily.XMoto.json
@@ -1,7 +1,7 @@
 {
     "app-id": "org.tuxfamily.XMoto",
     "runtime": "org.freedesktop.Platform",
-    "runtime-version": "20.08",
+    "runtime-version": "22.08",
     "sdk": "org.freedesktop.Sdk",
     "finish-args": [
         "--device=all",
@@ -15,7 +15,8 @@
         "/lib/pkgconfig",
         "/share/aclocal",
         "/share/man",
-        "*.la", "*.a"
+        "*.la",
+        "*.a"
     ],
     "modules": [
         "shared-modules/lua5.3/lua-5.3.5.json",
@@ -54,7 +55,7 @@
                 "LIBS=-lX11"
             ],
             "build-options": {
-                "cxxflags":"-fpermissive"
+                "cxxflags": "-fpermissive"
             },
             "cleanup": [
                 "/bin"
@@ -71,14 +72,14 @@
             "name": "xmoto",
             "buildsystem": "cmake-ninja",
             "builddir": true,
-            "config-opts" : [
+            "config-opts": [
                 "-DCMAKE_BUILD_TYPE=Release"
             ],
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://github.com/xmoto/xmoto/archive/0.6.1/0.6.1.tar.gz",
-                    "sha256": "209c8c38b1742d0620d40f90365c7a56f67c86da826c80a76d37fa46ee9c9b66"
+                    "url": "https://github.com/xmoto/xmoto/archive/refs/tags/v0.6.2.tar.gz",
+                    "sha256": "1ba54baaa1511f45497c1aadd6c8fda4917fd4e403466cdc92b5755b05c90de4"
                 },
                 {
                     "type": "patch",


### PR DESCRIPTION
I can't get this to build due to the following error while building `smpeg`:

```
libtool: Version mismatch error.  This is libtool 2.4.6, but the
libtool: definition of this LT_INIT comes from an older release.
libtool: You should recreate aclocal.m4 with macros from libtool 2.4.6
libtool: and run autoconf again.
make[1]: *** [Makefile:416: MPEGaudio.lo] Error 63
make[1]: *** Waiting for unfinished jobs....
libtool: Version mismatch error.  This is libtool 2.4.6, but the
libtool: definition of this LT_INIT comes from an older release.
libtool: You should recreate aclocal.m4 with macros from libtool 2.4.6
libtool: and run autoconf again.
libtool: Version mismatch error.  This is libtool 2.4.6, but the
libtool: definition of this LT_INIT comes from an older release.
libtool: You should recreate aclocal.m4 with macros from libtool 2.4.6
libtool: and run autoconf again.
make[1]: *** [Makefile:416: bitwindow.lo] Error 63
make[1]: *** [Makefile:416: mpeglayer3.lo] Error 63
libtool: Version mismatch error.  This is libtool 2.4.6, but the
libtool: definition of this LT_INIT comes from an older release.
libtool: You should recreate aclocal.m4 with macros from libtool 2.4.6
libtool: and run autoconf again.
libtool: Version mismatch error.  This is libtool 2.4.6, but the
libtool: definition of this LT_INIT comes from an older release.
libtool: You should recreate aclocal.m4 with macros from libtool 2.4.6
libtool: and run autoconf again.
make[1]: *** [Makefile:416: mpegtable.lo] Error 63
libtool: Version mismatch error.  This is libtool 2.4.6, but the
libtool: definition of this LT_INIT comes from an older release.
libtool: You should recreate aclocal.m4 with macros from libtool 2.4.6
libtool: and run autoconf again.
make[1]: *** [Makefile:416: mpeglayer1.lo] Error 63
make[1]: *** [Makefile:416: mpeglayer2.lo] Error 63
libtool: Version mismatch error.  This is libtool 2.4.6, but the
libtool: definition of this LT_INIT comes from an older release.
libtool: You should recreate aclocal.m4 with macros from libtool 2.4.6
libtool: and run autoconf again.
make[1]: *** [Makefile:416: filter_2.lo] Error 63
libtool: Version mismatch error.  This is libtool 2.4.6, but the
libtool: definition of this LT_INIT comes from an older release.
libtool: You should recreate aclocal.m4 with macros from libtool 2.4.6
libtool: and run autoconf again.
make[1]: *** [Makefile:416: filter.lo] Error 63
libtool: Version mismatch error.  This is libtool 2.4.6, but the
libtool: definition of this LT_INIT comes from an older release.
libtool: You should recreate aclocal.m4 with macros from libtool 2.4.6
libtool: and run autoconf again.
make[1]: *** [Makefile:416: mpegtoraw.lo] Error 63
libtool: Version mismatch error.  This is libtool 2.4.6, but the
libtool: definition of this LT_INIT comes from an older release.
libtool: You should recreate aclocal.m4 with macros from libtool 2.4.6
libtool: and run autoconf again.
make[1]: *** [Makefile:416: huffmantable.lo] Error 63
make[1]: Leaving directory '/run/build/smpeg/audio'
make: *** [Makefile:867: all-recursive] Error 1
Error: module smpeg: Child process exited with code 2
```

Any ideas why? I'm not well-versed in autotools.

- This closes https://github.com/flathub/org.tuxfamily.XMoto/issues/9.